### PR TITLE
Spawn fixes for ~40 Pokemon

### DIFF
--- a/common/src/main/resources/data/cobblemon/spawn_pool_world/0183_marill.json
+++ b/common/src/main/resources/data/cobblemon/spawn_pool_world/0183_marill.json
@@ -6,10 +6,6 @@
         {
             "id": "marill-1",
             "pokemon": "marill",
-            "presets": [
-                "natural",
-                "river"
-            ],
             "type": "pokemon",
             "context": "grounded",
             "bucket": "uncommon",

--- a/common/src/main/resources/data/cobblemon/spawn_pool_world/0184_azumarill.json
+++ b/common/src/main/resources/data/cobblemon/spawn_pool_world/0184_azumarill.json
@@ -6,10 +6,6 @@
         {
             "id": "azumarill-1",
             "pokemon": "azumarill",
-            "presets": [
-                "natural",
-                "river"
-            ],
             "type": "pokemon",
             "context": "grounded",
             "bucket": "rare",

--- a/common/src/main/resources/data/cobblemon/spawn_pool_world/0201_unown.json
+++ b/common/src/main/resources/data/cobblemon/spawn_pool_world/0201_unown.json
@@ -15,7 +15,6 @@
             "level": "4-55",
             "weight": 2,
             "condition": {
-                "canSeeSky": true,
                 "biomes": [
                     "#cobblemon:is_spooky"
                 ],

--- a/common/src/main/resources/data/cobblemon/spawn_pool_world/0223_remoraid.json
+++ b/common/src/main/resources/data/cobblemon/spawn_pool_world/0223_remoraid.json
@@ -7,8 +7,7 @@
             "id": "remoraid-1",
             "pokemon": "remoraid",
             "presets": [
-                "underwater",
-                "natural"
+                "underwater"
             ],
             "type": "pokemon",
             "context": "submerged",

--- a/common/src/main/resources/data/cobblemon/spawn_pool_world/0223_remoraid.json
+++ b/common/src/main/resources/data/cobblemon/spawn_pool_world/0223_remoraid.json
@@ -17,7 +17,7 @@
             "condition": {
                 "canSeeSky": true,
                 "biomes": [
-                    "#cobblemon:is_lukewarm"
+                    "#cobblemon:is_lukewarm_ocean"
                 ]
             }
         }

--- a/common/src/main/resources/data/cobblemon/spawn_pool_world/0224_octillery.json
+++ b/common/src/main/resources/data/cobblemon/spawn_pool_world/0224_octillery.json
@@ -7,8 +7,7 @@
             "id": "octillery-1",
             "pokemon": "octillery",
             "presets": [
-                "underwater",
-                "natural"
+                "underwater"
             ],
             "type": "pokemon",
             "context": "submerged",

--- a/common/src/main/resources/data/cobblemon/spawn_pool_world/0224_octillery.json
+++ b/common/src/main/resources/data/cobblemon/spawn_pool_world/0224_octillery.json
@@ -17,7 +17,7 @@
             "condition": {
                 "canSeeSky": true,
                 "biomes": [
-                    "#cobblemon:is_lukewarm"
+                    "#cobblemon:is_lukewarm_ocean"
                 ]
             }
         }

--- a/common/src/main/resources/data/cobblemon/spawn_pool_world/0226_mantine.json
+++ b/common/src/main/resources/data/cobblemon/spawn_pool_world/0226_mantine.json
@@ -17,7 +17,7 @@
             "condition": {
                 "canSeeSky": true,
                 "biomes": [
-                    "#cobblemon:is_lukewarm"
+                    "#cobblemon:is_lukewarm_ocean"
                 ]
             }
         }

--- a/common/src/main/resources/data/cobblemon/spawn_pool_world/0298_azurill.json
+++ b/common/src/main/resources/data/cobblemon/spawn_pool_world/0298_azurill.json
@@ -6,10 +6,6 @@
         {
             "id": "azurill-1",
             "pokemon": "azurill",
-            "presets": [
-                "natural",
-                "river"
-            ],
             "type": "pokemon",
             "context": "grounded",
             "bucket": "common",

--- a/common/src/main/resources/data/cobblemon/spawn_pool_world/0300_skitty.json
+++ b/common/src/main/resources/data/cobblemon/spawn_pool_world/0300_skitty.json
@@ -7,8 +7,7 @@
             "id": "skitty-1",
             "pokemon": "skitty",
             "presets": [
-                "natural",
-                "urban"
+                "natural"
             ],
             "type": "pokemon",
             "context": "grounded",

--- a/common/src/main/resources/data/cobblemon/spawn_pool_world/0301_delcatty.json
+++ b/common/src/main/resources/data/cobblemon/spawn_pool_world/0301_delcatty.json
@@ -7,8 +7,7 @@
             "id": "delcatty-1",
             "pokemon": "delcatty",
             "presets": [
-                "natural",
-                "urban"
+                "natural"
             ],
             "type": "pokemon",
             "context": "grounded",

--- a/common/src/main/resources/data/cobblemon/spawn_pool_world/0349_feebas.json
+++ b/common/src/main/resources/data/cobblemon/spawn_pool_world/0349_feebas.json
@@ -7,7 +7,6 @@
             "id": "feebas-1",
             "pokemon": "feebas",
             "presets": [
-                "freshwater",
                 "underwater"
             ],
             "type": "pokemon",

--- a/common/src/main/resources/data/cobblemon/spawn_pool_world/0349_feebas.json
+++ b/common/src/main/resources/data/cobblemon/spawn_pool_world/0349_feebas.json
@@ -15,7 +15,10 @@
             "level": "1-20",
             "weight": 9.9,
             "condition": {
-                "canSeeSky": true
+                "canSeeSky": true,
+                "biomes": [
+                    "#cobblemon:is_freshwater"
+                ]
             }
         }
     ]

--- a/common/src/main/resources/data/cobblemon/spawn_pool_world/0350_milotic.json
+++ b/common/src/main/resources/data/cobblemon/spawn_pool_world/0350_milotic.json
@@ -7,7 +7,6 @@
             "id": "milotic-1",
             "pokemon": "milotic",
             "presets": [
-                "freshwater",
                 "underwater"
             ],
             "type": "pokemon",
@@ -16,7 +15,10 @@
             "level": "20-55",
             "weight": 9.9,
             "condition": {
-                "canSeeSky": true
+                "canSeeSky": true,
+                "biomes": [
+                    "#cobblemon:is_freshwater"
+                ]
             }
         }
     ]

--- a/common/src/main/resources/data/cobblemon/spawn_pool_world/0353_shuppet.json
+++ b/common/src/main/resources/data/cobblemon/spawn_pool_world/0353_shuppet.json
@@ -15,7 +15,6 @@
             "level": "12-39",
             "weight": 9.0,
             "condition": {
-                "canSeeSky": true,
                 "biomes": [
                     "#cobblemon:is_spooky"
                 ],

--- a/common/src/main/resources/data/cobblemon/spawn_pool_world/0353_shuppet.json
+++ b/common/src/main/resources/data/cobblemon/spawn_pool_world/0353_shuppet.json
@@ -7,8 +7,7 @@
             "id": "shuppet-1",
             "pokemon": "shuppet",
             "presets": [
-                "natural",
-                "urban"
+                "natural"
             ],
             "type": "pokemon",
             "context": "grounded",

--- a/common/src/main/resources/data/cobblemon/spawn_pool_world/0354_banette.json
+++ b/common/src/main/resources/data/cobblemon/spawn_pool_world/0354_banette.json
@@ -7,8 +7,7 @@
             "id": "banette-1",
             "pokemon": "banette",
             "presets": [
-                "natural",
-                "urban"
+                "natural"
             ],
             "type": "pokemon",
             "context": "grounded",

--- a/common/src/main/resources/data/cobblemon/spawn_pool_world/0354_banette.json
+++ b/common/src/main/resources/data/cobblemon/spawn_pool_world/0354_banette.json
@@ -15,7 +15,6 @@
             "level": "37-55",
             "weight": 9.0,
             "condition": {
-                "canSeeSky": true,
                 "biomes": [
                     "#cobblemon:is_spooky"
                 ],

--- a/common/src/main/resources/data/cobblemon/spawn_pool_world/0431_glameow.json
+++ b/common/src/main/resources/data/cobblemon/spawn_pool_world/0431_glameow.json
@@ -7,8 +7,7 @@
             "id": "glameow-1",
             "pokemon": "glameow",
             "presets": [
-                "natural",
-                "urban"
+                "natural"
             ],
             "type": "pokemon",
             "context": "grounded",

--- a/common/src/main/resources/data/cobblemon/spawn_pool_world/0432_purugly.json
+++ b/common/src/main/resources/data/cobblemon/spawn_pool_world/0432_purugly.json
@@ -7,8 +7,7 @@
             "id": "purugly-1",
             "pokemon": "purugly",
             "presets": [
-                "natural",
-                "urban"
+                "natural"
             ],
             "type": "pokemon",
             "context": "grounded",

--- a/common/src/main/resources/data/cobblemon/spawn_pool_world/0458_mantyke.json
+++ b/common/src/main/resources/data/cobblemon/spawn_pool_world/0458_mantyke.json
@@ -7,8 +7,7 @@
             "id": "mantyke-1",
             "pokemon": "mantyke",
             "presets": [
-                "underwater",
-                "natural"
+                "underwater"
             ],
             "type": "pokemon",
             "context": "submerged",

--- a/common/src/main/resources/data/cobblemon/spawn_pool_world/0458_mantyke.json
+++ b/common/src/main/resources/data/cobblemon/spawn_pool_world/0458_mantyke.json
@@ -17,7 +17,7 @@
             "condition": {
                 "canSeeSky": true,
                 "biomes": [
-                    "#cobblemon:is_lukewarm"
+                    "#cobblemon:is_lukewarm_ocean"
                 ]
             }
         }

--- a/common/src/main/resources/data/cobblemon/spawn_pool_world/0479_rotom.json
+++ b/common/src/main/resources/data/cobblemon/spawn_pool_world/0479_rotom.json
@@ -7,8 +7,7 @@
             "id": "rotom-1",
             "pokemon": "rotom",
             "presets": [
-                "natural",
-                "urban"
+                "natural"
             ],
             "type": "pokemon",
             "context": "grounded",

--- a/common/src/main/resources/data/cobblemon/spawn_pool_world/0494_victini.json
+++ b/common/src/main/resources/data/cobblemon/spawn_pool_world/0494_victini.json
@@ -7,8 +7,7 @@
             "id": "victini-1",
             "pokemon": "victini",
             "presets": [
-                "natural",
-                "urban"
+                "natural"
             ],
             "type": "pokemon",
             "context": "grounded",

--- a/common/src/main/resources/data/cobblemon/spawn_pool_world/0517_munna.json
+++ b/common/src/main/resources/data/cobblemon/spawn_pool_world/0517_munna.json
@@ -7,8 +7,7 @@
             "id": "munna-1",
             "pokemon": "munna",
             "presets": [
-                "natural",
-                "urban"
+                "natural"
             ],
             "type": "pokemon",
             "context": "grounded",

--- a/common/src/main/resources/data/cobblemon/spawn_pool_world/0517_munna.json
+++ b/common/src/main/resources/data/cobblemon/spawn_pool_world/0517_munna.json
@@ -15,7 +15,6 @@
             "level": "12-39",
             "weight": 9.0,
             "condition": {
-                "canSeeSky": true,
                 "biomes": [
                     "#cobblemon:is_spooky"
                 ],

--- a/common/src/main/resources/data/cobblemon/spawn_pool_world/0518_musharna.json
+++ b/common/src/main/resources/data/cobblemon/spawn_pool_world/0518_musharna.json
@@ -15,7 +15,6 @@
             "level": "12-39",
             "weight": 9.0,
             "condition": {
-                "canSeeSky": true,
                 "biomes": [
                     "#cobblemon:is_spooky"
                 ],

--- a/common/src/main/resources/data/cobblemon/spawn_pool_world/0518_musharna.json
+++ b/common/src/main/resources/data/cobblemon/spawn_pool_world/0518_musharna.json
@@ -7,8 +7,7 @@
             "id": "musharna-1",
             "pokemon": "musharna",
             "presets": [
-                "natural",
-                "urban"
+                "natural"
             ],
             "type": "pokemon",
             "context": "grounded",

--- a/common/src/main/resources/data/cobblemon/spawn_pool_world/0574_gothita.json
+++ b/common/src/main/resources/data/cobblemon/spawn_pool_world/0574_gothita.json
@@ -7,8 +7,7 @@
             "id": "gothita-1",
             "pokemon": "gothita",
             "presets": [
-                "natural",
-                "urban"
+                "natural"
             ],
             "type": "pokemon",
             "context": "grounded",

--- a/common/src/main/resources/data/cobblemon/spawn_pool_world/0575_gothorita.json
+++ b/common/src/main/resources/data/cobblemon/spawn_pool_world/0575_gothorita.json
@@ -7,8 +7,7 @@
             "id": "gothorita-1",
             "pokemon": "gothorita",
             "presets": [
-                "natural",
-                "urban"
+                "natural"
             ],
             "type": "pokemon",
             "context": "grounded",

--- a/common/src/main/resources/data/cobblemon/spawn_pool_world/0576_gothitelle.json
+++ b/common/src/main/resources/data/cobblemon/spawn_pool_world/0576_gothitelle.json
@@ -7,8 +7,7 @@
             "id": "gothitelle-1",
             "pokemon": "gothitelle",
             "presets": [
-                "natural",
-                "urban"
+                "natural"
             ],
             "type": "pokemon",
             "context": "grounded",

--- a/common/src/main/resources/data/cobblemon/spawn_pool_world/0577_solosis.json
+++ b/common/src/main/resources/data/cobblemon/spawn_pool_world/0577_solosis.json
@@ -7,8 +7,7 @@
             "id": "solosis-1",
             "pokemon": "solosis",
             "presets": [
-                "natural",
-                "urban"
+                "natural"
             ],
             "type": "pokemon",
             "context": "grounded",

--- a/common/src/main/resources/data/cobblemon/spawn_pool_world/0578_duosion.json
+++ b/common/src/main/resources/data/cobblemon/spawn_pool_world/0578_duosion.json
@@ -7,8 +7,7 @@
             "id": "duosion-1",
             "pokemon": "duosion",
             "presets": [
-                "natural",
-                "urban"
+                "natural"
             ],
             "type": "pokemon",
             "context": "grounded",

--- a/common/src/main/resources/data/cobblemon/spawn_pool_world/0579_reuniclus.json
+++ b/common/src/main/resources/data/cobblemon/spawn_pool_world/0579_reuniclus.json
@@ -7,8 +7,7 @@
             "id": "reuniclus-1",
             "pokemon": "reuniclus",
             "presets": [
-                "natural",
-                "urban"
+                "natural"
             ],
             "type": "pokemon",
             "context": "grounded",

--- a/common/src/main/resources/data/cobblemon/spawn_pool_world/0676_furfrou.json
+++ b/common/src/main/resources/data/cobblemon/spawn_pool_world/0676_furfrou.json
@@ -7,8 +7,7 @@
             "id": "furfrou-1",
             "pokemon": "furfrou",
             "presets": [
-                "natural",
-                "urban"
+                "natural"
             ],
             "type": "pokemon",
             "context": "grounded",

--- a/common/src/main/resources/data/cobblemon/spawn_pool_world/0677_espurr.json
+++ b/common/src/main/resources/data/cobblemon/spawn_pool_world/0677_espurr.json
@@ -7,8 +7,7 @@
             "id": "espurr-1",
             "pokemon": "espurr",
             "presets": [
-                "natural",
-                "urban"
+                "natural"
             ],
             "type": "pokemon",
             "context": "grounded",

--- a/common/src/main/resources/data/cobblemon/spawn_pool_world/0678_meowstic.json
+++ b/common/src/main/resources/data/cobblemon/spawn_pool_world/0678_meowstic.json
@@ -7,8 +7,7 @@
             "id": "meowstic-1",
             "pokemon": "meowstic",
             "presets": [
-                "natural",
-                "urban"
+                "natural"
             ],
             "type": "pokemon",
             "context": "grounded",

--- a/common/src/main/resources/data/cobblemon/spawn_pool_world/0686_inkay.json
+++ b/common/src/main/resources/data/cobblemon/spawn_pool_world/0686_inkay.json
@@ -7,8 +7,7 @@
             "id": "inkay-1",
             "pokemon": "inkay",
             "presets": [
-                "underwater",
-                "natural"
+                "underwater"
             ],
             "type": "pokemon",
             "context": "submerged",

--- a/common/src/main/resources/data/cobblemon/spawn_pool_world/0686_inkay.json
+++ b/common/src/main/resources/data/cobblemon/spawn_pool_world/0686_inkay.json
@@ -17,7 +17,7 @@
             "condition": {
                 "canSeeSky": true,
                 "biomes": [
-                    "#cobblemon:is_lukewarm"
+                    "#cobblemon:is_lukewarm_ocean"
                 ]
             }
         }

--- a/common/src/main/resources/data/cobblemon/spawn_pool_world/0687_malamar.json
+++ b/common/src/main/resources/data/cobblemon/spawn_pool_world/0687_malamar.json
@@ -7,8 +7,7 @@
             "id": "malamar-1",
             "pokemon": "malamar",
             "presets": [
-                "underwater",
-                "natural"
+                "underwater"
             ],
             "type": "pokemon",
             "context": "submerged",

--- a/common/src/main/resources/data/cobblemon/spawn_pool_world/0687_malamar.json
+++ b/common/src/main/resources/data/cobblemon/spawn_pool_world/0687_malamar.json
@@ -17,7 +17,7 @@
             "condition": {
                 "canSeeSky": true,
                 "biomes": [
-                    "#cobblemon:is_lukewarm"
+                    "#cobblemon:is_lukewarm_ocean"
                 ]
             }
         }

--- a/common/src/main/resources/data/cobblemon/spawn_pool_world/0693_clawitzer.json
+++ b/common/src/main/resources/data/cobblemon/spawn_pool_world/0693_clawitzer.json
@@ -7,8 +7,7 @@
             "id": "clawitzer-1",
             "pokemon": "clawitzer",
             "presets": [
-                "underwater",
-                "natural"
+                "underwater"
             ],
             "type": "pokemon",
             "context": "submerged",

--- a/common/src/main/resources/data/cobblemon/spawn_pool_world/0748_toxapex.json
+++ b/common/src/main/resources/data/cobblemon/spawn_pool_world/0748_toxapex.json
@@ -7,8 +7,7 @@
             "id": "toxapex-1",
             "pokemon": "toxapex",
             "presets": [
-                "underwater",
-                "natural"
+                "underwater"
             ],
             "type": "pokemon",
             "context": "submerged",

--- a/common/src/main/resources/data/cobblemon/spawn_pool_world/0866_mrrime.json
+++ b/common/src/main/resources/data/cobblemon/spawn_pool_world/0866_mrrime.json
@@ -7,8 +7,7 @@
             "id": "mrrime-1",
             "pokemon": "mrrime",
             "presets": [
-                "natural",
-                "urban"
+                "natural"
             ],
             "type": "pokemon",
             "context": "grounded",

--- a/common/src/main/resources/data/cobblemon/spawn_pool_world/0963_finizen.json
+++ b/common/src/main/resources/data/cobblemon/spawn_pool_world/0963_finizen.json
@@ -7,8 +7,7 @@
             "id": "finizen-1",
             "pokemon": "finizen",
             "presets": [
-                "underwater",
-                "natural"
+                "underwater"
             ],
             "type": "pokemon",
             "context": "submerged",

--- a/common/src/main/resources/data/cobblemon/spawn_pool_world/0963_finizen.json
+++ b/common/src/main/resources/data/cobblemon/spawn_pool_world/0963_finizen.json
@@ -17,7 +17,7 @@
             "condition": {
                 "canSeeSky": true,
                 "biomes": [
-                    "#cobblemon:is_lukewarm"
+                    "#cobblemon:is_lukewarm_ocean"
                 ]
             }
         }

--- a/common/src/main/resources/data/cobblemon/spawn_pool_world/0964_palafin.json
+++ b/common/src/main/resources/data/cobblemon/spawn_pool_world/0964_palafin.json
@@ -7,8 +7,7 @@
             "id": "palafin-1",
             "pokemon": "palafin",
             "presets": [
-                "underwater",
-                "natural"
+                "underwater"
             ],
             "type": "pokemon",
             "context": "submerged",

--- a/common/src/main/resources/data/cobblemon/spawn_pool_world/0964_palafin.json
+++ b/common/src/main/resources/data/cobblemon/spawn_pool_world/0964_palafin.json
@@ -17,7 +17,7 @@
             "condition": {
                 "canSeeSky": true,
                 "biomes": [
-                    "#cobblemon:is_lukewarm"
+                    "#cobblemon:is_lukewarm_ocean"
                 ]
             }
         }

--- a/common/src/main/resources/data/cobblemon/spawn_pool_world/0967_cyclizar.json
+++ b/common/src/main/resources/data/cobblemon/spawn_pool_world/0967_cyclizar.json
@@ -7,8 +7,7 @@
             "id": "cyclizar-1",
             "pokemon": "cyclizar",
             "presets": [
-                "natural",
-                "urban"
+                "natural"
             ],
             "type": "pokemon",
             "context": "grounded",


### PR DESCRIPTION
Generally removes conflicting double preset requirements, canSeeSky requirement removed for spooky because dark forests typically don't see the sky,  is_lukewarm -> is_lukewarm_ocean fix